### PR TITLE
fix multibyte post requests

### DIFF
--- a/elmine.el
+++ b/elmine.el
@@ -231,7 +231,7 @@ going to be hashtables and JSON arrays are going to be lists."
   (let ((json-object-type 'plist)
         (json-array-type 'list))
     (condition-case err
-        (json-encode object)
+        (encode-coding-string (json-encode object) 'utf-8)
       (json-readtable-error
        (message "%s: Could not encode object into JSON string. See %s"
                 (error-message-string err) object)))))


### PR DESCRIPTION
Current implementation fails to submit POST requests with multibyte content (unicode Russian, Japanese, Chinese, etc):

```elisp
(elmine/create-time-entry
 :issue_id 1 :activity_id 2
 :hours "1:00" :comments "тест")
```
`url-http-create-request: Multibyte text in HTTP request: POST /time_entries.json HTTP/1.1`

and even when i encode my comment like this 

```elisp
(elmine/create-time-entry
 :issue_id 1 :activity_id 2
 :hours "1:00" :comments (encode-coding-string "тест" 'utf-8))
```
error still raised.

This happens because underlying `json-encode` call in `elmine/api-encode` returns **multibyte** instead of required by `url-http-create-request` **unibyte**.
