### PR TITLE
Default filters for get-issues

### DIFF
--- a/elmine.el
+++ b/elmine.el
@@ -242,7 +242,7 @@ going to be hashtables and JSON arrays are going to be lists."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (defun elmine/get-issues (&rest filters)
   "Get a list of issues."
-  (let ((filters (plist-merge '(:status_id "open") filters)))
+  (let ((filters (plist-merge '(:limit 100) filters)))
     (apply #'elmine/api-get-all :issues "/issues.json" filters)))
 
 (defun elmine/get-issue (id &rest params)


### PR DESCRIPTION
Is there the reason to retrieve only open issues? Maybe it would be better to limit list by issues count by default and leave further filtration to library users?